### PR TITLE
GUI-Prototyp für Mac-Assistenten hinzufügen

### DIFF
--- a/gui/AssistantManager.swift
+++ b/gui/AssistantManager.swift
@@ -1,0 +1,213 @@
+// 
+// AssistantManager.swift - Zustandsverwaltung für den Mac-Assistenten
+// Erstellt am: 2025-05-04
+// Änderungen:
+// - Initiale Implementierung des AssistantManager
+// - Zustandsverwaltung und Python-Bridge integriert
+// - Kommunikationslogik mit dem Backend implementiert
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+// Python-Bridge-Import würde hier erfolgen
+// import PythonKit in einer vollständigen Implementierung
+
+class AssistantManager: ObservableObject {
+    // Singleton-Instance für globalen Zugriff
+    static let shared = AssistantManager()
+    
+    // Veröffentlichte Eigenschaften für SwiftUI-Binding
+    @Published var isListening: Bool = false
+    @Published var isProcessing: Bool = false
+    @Published var assistantResponse: String = ""
+    @Published var conversationHistory: [Message] = []
+    @Published var lastScreenAnalysis: String = ""
+    @Published var activeCommand: String = ""
+    
+    // Konfiguration
+    @Published var apiModel: String = "openai" // "openai" oder "gemini"
+    @Published var voiceEnabled: Bool = true
+    @Published var screenAnalysisEnabled: Bool = true
+    @Published var wakeWord: String = "Assistent"
+    
+    // Python-Bridge (würde in der vollständigen Implementierung initialisiert)
+    // private var pythonBridge: PythonBridge?
+    
+    // Einstellungs-Fenster-Verwaltung
+    @Published var isSettingsWindowShown: Bool = false
+    
+    private init() {
+        loadSettings()
+        // In einer vollständigen Implementierung:
+        // initializePythonBridge()
+    }
+    
+    // MARK: - Public Interface
+    
+    /// Startet den Assistenten
+    func startAssistant() {
+        guard !isProcessing else { return }
+        
+        isProcessing = true
+        
+        // In einer vollständigen Implementierung:
+        // Starte Python-Backend über die Bridge
+        // pythonBridge?.startAssistant()
+        
+        isProcessing = false
+        
+        // Simulierte Startmeldung (in der echten App würde dies vom Backend kommen)
+        self.addMessage(
+            Message(
+                content: "Hallo! Ich bin dein Mac-Assistent. Wie kann ich dir helfen?",
+                isFromUser: false,
+                timestamp: Date()
+            )
+        )
+        
+        isListening = true
+    }
+    
+    /// Stoppt den Assistenten
+    func stopAssistant() {
+        guard !isProcessing else { return }
+        
+        isProcessing = true
+        
+        // In einer vollständigen Implementierung:
+        // Stoppe Python-Backend über die Bridge
+        // pythonBridge?.stopAssistant()
+        
+        isProcessing = false
+        isListening = false
+        
+        // Simulierte Stoppnachricht
+        self.addMessage(
+            Message(
+                content: "Assistant wurde gestoppt.",
+                isFromUser: false,
+                timestamp: Date()
+            )
+        )
+    }
+    
+    /// Sendet einen Befehl an den Assistenten
+    func sendCommand(_ command: String) {
+        guard !command.isEmpty else { return }
+        
+        isProcessing = true
+        activeCommand = command
+        
+        // Befehl zur Historie hinzufügen
+        self.addMessage(Message(content: command, isFromUser: true, timestamp: Date()))
+        
+        // In einer vollständigen Implementierung:
+        // Sende Befehl an Python-Backend und verarbeite Antwort asynchron
+        // Task {
+        //     let response = await pythonBridge?.sendCommand(command) ?? "Keine Antwort erhalten."
+        //     await MainActor.run {
+        //         self.handleResponse(response)
+        //     }
+        // }
+        
+        // SIMULIERTE ANTWORT (nur für Prototyp)
+        // In der echten App würde dies asynchron vom Python-Backend kommen
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let simulatedResponse = self.simulateResponse(to: command)
+            self.handleResponse(simulatedResponse)
+        }
+    }
+    
+    /// Zeigt das Einstellungsfenster an
+    func showSettings() {
+        isSettingsWindowShown = true
+    }
+    
+    // MARK: - Private Methods
+    
+    private func loadSettings() {
+        // In einer vollständigen Implementierung:
+        // Lade gespeicherte Einstellungen aus UserDefaults oder einer Konfigurationsdatei
+        
+        // Beispiel:
+        let defaults = UserDefaults.standard
+        apiModel = defaults.string(forKey: "apiModel") ?? "openai"
+        voiceEnabled = defaults.bool(forKey: "voiceEnabled")
+        screenAnalysisEnabled = defaults.bool(forKey: "screenAnalysisEnabled")
+        wakeWord = defaults.string(forKey: "wakeWord") ?? "Assistent"
+    }
+    
+    private func saveSettings() {
+        // In einer vollständigen Implementierung:
+        // Speichere Einstellungen in UserDefaults oder einer Konfigurationsdatei
+        
+        // Beispiel:
+        let defaults = UserDefaults.standard
+        defaults.set(apiModel, forKey: "apiModel")
+        defaults.set(voiceEnabled, forKey: "voiceEnabled")
+        defaults.set(screenAnalysisEnabled, forKey: "screenAnalysisEnabled")
+        defaults.set(wakeWord, forKey: "wakeWord")
+    }
+    
+    private func addMessage(_ message: Message) {
+        // Füge eine Nachricht zur Konversationshistorie hinzu
+        DispatchQueue.main.async {
+            self.conversationHistory.append(message)
+            
+            // Beschränke die Historie auf die letzten 50 Nachrichten, um Speicher zu sparen
+            if self.conversationHistory.count > 50 {
+                self.conversationHistory.removeFirst()
+            }
+        }
+    }
+    
+    private func handleResponse(_ response: String) {
+        // Antwort vom Backend verarbeiten
+        self.assistantResponse = response
+        
+        // Antwort zur Historie hinzufügen
+        self.addMessage(Message(content: response, isFromUser: false, timestamp: Date()))
+        
+        // Status zurücksetzen
+        self.isProcessing = false
+        self.activeCommand = ""
+    }
+    
+    // SIMULIERTE ANTWORT (nur für Prototyp)
+    private func simulateResponse(to command: String) -> String {
+        let commandLower = command.lowercased()
+        
+        if commandLower.contains("hallo") || commandLower.contains("hi") {
+            return "Hallo! Wie kann ich dir helfen?"
+        } else if commandLower.contains("öffne") && commandLower.contains("safari") {
+            return "Ich öffne Safari für dich."
+        } else if commandLower.contains("schließe") {
+            return "Ich schließe die Anwendung für dich."
+        } else if commandLower.contains("mail") || commandLower.contains("email") {
+            return "Möchtest du eine neue E-Mail erstellen oder deine Mails überprüfen?"
+        } else if commandLower.contains("uhrzeit") || commandLower.contains("zeit") {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            let timeString = formatter.string(from: Date())
+            return "Es ist jetzt \(timeString) Uhr."
+        } else if commandLower.contains("hilfe") {
+            return "Ich kann dir bei vielen Aufgaben helfen: Anwendungen öffnen und schließen, Text eingeben, Informationen suchen und vieles mehr. Was möchtest du tun?"
+        } else {
+            return "Ich verstehe deine Anfrage. Wie kann ich dir dabei helfen?"
+        }
+    }
+}
+
+// Struktur für Konversationsnachrichten
+struct Message: Identifiable, Equatable {
+    let id = UUID()
+    let content: String
+    let isFromUser: Bool
+    let timestamp: Date
+    
+    static func == (lhs: Message, rhs: Message) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/gui/MacAssistantApp.swift
+++ b/gui/MacAssistantApp.swift
@@ -1,0 +1,93 @@
+// 
+// MacAssistantApp.swift - Hauptapplikation für den Mac-Assistenten
+// Erstellt am: 2025-05-04
+// Änderungen:
+// - Initiale Implementierung der SwiftUI-App
+// - Menübar-Status-Icon eingerichtet
+// - Integration mit AppDelegate
+//
+
+import SwiftUI
+
+@main
+struct MacAssistantApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var assistantManager = AssistantManager()
+    
+    var body: some Scene {
+        WindowGroup {
+            // Diese App hat kein Hauptfenster, nur ein Statusleisten-Icon
+            EmptyView()
+        }
+        .commands {
+            // Menübefehle für die App
+            CommandGroup(replacing: .appInfo) {
+                Button("Über Mac Assistant") {
+                    appDelegate.showAboutPanel()
+                }
+            }
+            
+            CommandGroup(replacing: .appSettings) {
+                Button("Einstellungen...") {
+                    assistantManager.showSettings()
+                }
+            }
+        }
+    }
+}
+
+// AppDelegate für zusätzliche Funktionalität
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var statusBarItem: NSStatusItem!
+    var popover: NSPopover!
+    var assistantController: AssistantViewController!
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Erstellen des Status-Bar-Elements
+        statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        
+        if let button = statusBarItem.button {
+            button.image = NSImage(systemSymbolName: "waveform.circle", accessibilityDescription: "Mac Assistant")
+            button.action = #selector(togglePopover(_:))
+        }
+        
+        // Popover für die Hauptansicht einrichten
+        popover = NSPopover()
+        popover.contentSize = NSSize(width: 360, height: 512)
+        popover.behavior = .transient
+        
+        // SwiftUI-Ansicht in das Popover einfügen
+        popover.contentViewController = NSHostingController(
+            rootView: PopoverView()
+                .environmentObject(AssistantManager.shared)
+        )
+    }
+    
+    @objc func togglePopover(_ sender: AnyObject?) {
+        if let button = statusBarItem.button {
+            if popover.isShown {
+                popover.performClose(sender)
+            } else {
+                popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
+                popover.contentViewController?.view.window?.makeKey()
+            }
+        }
+    }
+    
+    func showAboutPanel() {
+        let options: [NSApplication.AboutPanelOptionKey: Any] = [
+            .applicationName: "Mac Assistant",
+            .applicationVersion: "1.0.0",
+            .credits: NSAttributedString(
+                string: "Entwickelt mit ❤️ von Windsurf Engineering",
+                attributes: [
+                    .foregroundColor: NSColor.labelColor,
+                    .font: NSFont.systemFont(ofSize: 12)
+                ]
+            ),
+            .applicationIcon: NSImage(named: "AppIcon") ?? NSImage()
+        ]
+        
+        NSApplication.shared.orderFrontStandardAboutPanel(options: options)
+    }
+}

--- a/gui/PopoverView.swift
+++ b/gui/PopoverView.swift
@@ -1,0 +1,280 @@
+// 
+// PopoverView.swift - Hauptansicht für den Mac-Assistenten-Popover
+// Erstellt am: 2025-05-04
+// Änderungen:
+// - Initiale Implementierung der PopoverView
+// - Chat-Interface und Steuerungselemente implementiert
+// - Bildschirmanalyse-Anzeige integriert
+//
+
+import SwiftUI
+
+struct PopoverView: View {
+    @EnvironmentObject var assistantManager: AssistantManager
+    @State private var commandInput: String = ""
+    @State private var isInputFocused: Bool = false
+    
+    // Audio-Visualisierung (simuliert)
+    @State private var audioLevels: [CGFloat] = [0.2, 0.5, 0.8, 0.4, 0.3, 0.6, 0.7, 0.3]
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header mit Status
+            HeaderView(isListening: $assistantManager.isListening)
+            
+            // Chat-Verlauf
+            ScrollViewReader { scrollView in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(assistantManager.conversationHistory) { message in
+                            MessageView(message: message)
+                                .id(message.id)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                }
+                .onChange(of: assistantManager.conversationHistory.count) { _ in
+                    if let lastMessage = assistantManager.conversationHistory.last {
+                        withAnimation {
+                            scrollView.scrollTo(lastMessage.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            
+            // Trennlinie
+            Divider()
+            
+            // Bildschirmanalyse-Indikator
+            if assistantManager.screenAnalysisEnabled && !assistantManager.lastScreenAnalysis.isEmpty {
+                ScreenAnalysisView(analysis: assistantManager.lastScreenAnalysis)
+            }
+            
+            if assistantManager.isProcessing {
+                // Lade-Indikator
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                        .scaleEffect(0.8)
+                    Text("Verarbeite...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+            } else if assistantManager.isListening && assistantManager.voiceEnabled {
+                // Audio-Visualisierung
+                AudioVisualizerView(levels: $audioLevels)
+                    .frame(height: 30)
+                    .padding(.vertical, 4)
+                    .onAppear {
+                        startAudioSimulation()
+                    }
+            }
+            
+            // Eingabebereich
+            HStack(spacing: 8) {
+                // Sprach-Toggle
+                Button(action: {
+                    if assistantManager.isListening {
+                        assistantManager.stopAssistant()
+                    } else {
+                        assistantManager.startAssistant()
+                    }
+                }) {
+                    Image(systemName: assistantManager.isListening ? "mic.fill" : "mic")
+                        .font(.system(size: 16))
+                        .foregroundColor(assistantManager.isListening ? .red : .accentColor)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            Circle()
+                                .fill(Color.accentColor.opacity(0.1))
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help(assistantManager.isListening ? "Spracherkennung deaktivieren" : "Spracherkennung aktivieren")
+                
+                // Texteingabe
+                TextField("Befehl eingeben...", text: $commandInput, onCommit: sendCommand)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .disabled(assistantManager.isProcessing)
+                
+                // Senden-Button
+                Button(action: sendCommand) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(
+                            commandInput.isEmpty || assistantManager.isProcessing 
+                            ? .gray 
+                            : .accentColor
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(commandInput.isEmpty || assistantManager.isProcessing)
+                .help("Befehl senden")
+            }
+            .padding()
+        }
+        .frame(width: 360)
+    }
+    
+    private func sendCommand() {
+        guard !commandInput.isEmpty && !assistantManager.isProcessing else { return }
+        
+        let command = commandInput
+        commandInput = ""
+        
+        assistantManager.sendCommand(command)
+    }
+    
+    // Simuliert die Audio-Visualisierung
+    private func startAudioSimulation() {
+        // In einer echten App würde dies auf tatsächlichen Audiodaten basieren
+        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
+            guard assistantManager.isListening && assistantManager.voiceEnabled else {
+                timer.invalidate()
+                return
+            }
+            
+            // Simuliere Änderungen in den Audiopegeln
+            withAnimation {
+                audioLevels = audioLevels.map { _ in
+                    CGFloat.random(in: 0.1...0.9)
+                }
+            }
+        }
+    }
+}
+
+// Header-Komponente
+struct HeaderView: View {
+    @Binding var isListening: Bool
+    
+    var body: some View {
+        HStack {
+            // Icon und Titel
+            Image(systemName: "waveform.circle.fill")
+                .font(.system(size: 24))
+                .foregroundColor(.accentColor)
+            
+            Text("Mac Assistant")
+                .font(.headline)
+            
+            Spacer()
+            
+            // Status-Anzeige
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(isListening ? Color.green : Color.gray)
+                    .frame(width: 8, height: 8)
+                
+                Text(isListening ? "Aktiv" : "Inaktiv")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+}
+
+// Nachrichten-Komponente
+struct MessageView: View {
+    let message: Message
+    
+    var body: some View {
+        HStack {
+            if message.isFromUser {
+                Spacer()
+            }
+            
+            VStack(alignment: message.isFromUser ? .trailing : .leading, spacing: 4) {
+                Text(message.content)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(message.isFromUser 
+                                  ? Color.accentColor
+                                  : Color(NSColor.controlBackgroundColor))
+                    )
+                    .foregroundColor(message.isFromUser ? .white : .primary)
+                
+                // Zeitstempel
+                Text(formatTimestamp(message.timestamp))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 4)
+            }
+            
+            if !message.isFromUser {
+                Spacer()
+            }
+        }
+    }
+    
+    private func formatTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// Bildschirmanalyse-Anzeige
+struct ScreenAnalysisView: View {
+    let analysis: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: "eye")
+                    .font(.caption)
+                
+                Text("Bildschirmanalyse")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                
+                Spacer()
+            }
+            
+            Text(analysis)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .truncationMode(.tail)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.5))
+    }
+}
+
+// Audio-Visualisierung
+struct AudioVisualizerView: View {
+    @Binding var levels: [CGFloat]
+    
+    var body: some View {
+        HStack(spacing: 3) {
+            Spacer()
+            
+            ForEach(0..<levels.count, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.accentColor)
+                    .frame(width: 3, height: 20 * levels[index])
+                    .animation(.easeInOut(duration: 0.1), value: levels[index])
+            }
+            
+            Spacer()
+        }
+    }
+}
+
+// Vorschau für SwiftUI-Canvas
+struct PopoverView_Previews: PreviewProvider {
+    static var previews: some View {
+        PopoverView()
+            .environmentObject(AssistantManager.shared)
+            .frame(width: 360, height: 512)
+    }
+}

--- a/gui/PythonBridge.swift
+++ b/gui/PythonBridge.swift
@@ -1,0 +1,227 @@
+// 
+// PythonBridge.swift - Integration zwischen Swift-UI und Python-Backend
+// Erstellt am: 2025-05-04
+// Änderungen:
+// - Initiale Implementierung der Python-Bridge
+// - Schnittstelle für die Kommunikation mit dem Backend
+// - Asynchrone Callback-Methoden für Ereignisbenachrichtigungen
+//
+
+import Foundation
+import Combine
+
+// In einer vollständigen Implementierung würden wir PythonKit importieren
+// import PythonKit
+
+/// Klasse zur Kommunikation mit dem Python-Backend
+class PythonBridge {
+    // Singleton-Instance für globalen Zugriff
+    static let shared = PythonBridge()
+    
+    // Ereignis-Publisher
+    var screenAnalysisPublisher = PassthroughSubject<String, Never>()
+    var speechCommandPublisher = PassthroughSubject<String, Never>()
+    var assistantStatusPublisher = PassthroughSubject<Bool, Never>()
+    
+    // Python-Module (würden in einer vollständigen Implementierung initialisiert)
+    // private var sys: PythonObject?
+    // private var assistant: PythonObject?
+    // private var aiService: PythonObject?
+    // private var voiceManager: PythonObject?
+    // private var screenManager: PythonObject?
+    
+    private init() {
+        // Simuliere die Initialisierung für den Prototyp
+        print("PythonBridge wird initialisiert...")
+        
+        // In einer vollständigen Implementierung:
+        // initializePythonRuntime()
+    }
+    
+    /// Initialisiert die Python-Laufzeitumgebung
+    private func initializePythonRuntime() {
+        // In einer vollständigen Implementierung:
+        /*
+        do {
+            // Python-Pfad setzen
+            sys = Python.import("sys")
+            let pythonPath = Bundle.main.resourcePath! + "/python"
+            sys!.path.append(pythonPath)
+            
+            // Module importieren
+            assistant = Python.import("assistant")
+            aiService = Python.import("ai_service")
+            voiceManager = Python.import("voice")
+            screenManager = Python.import("screen")
+            
+            print("Python-Module erfolgreich geladen")
+        } catch {
+            print("Fehler beim Initialisieren der Python-Laufzeit: \(error)")
+        }
+        */
+    }
+    
+    /// Startet den Assistenten
+    func startAssistant(completion: @escaping (Bool) -> Void) {
+        // In einer vollständigen Implementierung:
+        /*
+        do {
+            let result = assistant!.start()
+            completion(Bool(result)!)
+        } catch {
+            print("Fehler beim Starten des Assistenten: \(error)")
+            completion(false)
+        }
+        */
+        
+        // Simulierter Start für den Prototyp
+        print("Assistent wird gestartet...")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.assistantStatusPublisher.send(true)
+            completion(true)
+            
+            // Starte simulierte Ereignisse
+            self.startSimulatedEvents()
+        }
+    }
+    
+    /// Stoppt den Assistenten
+    func stopAssistant(completion: @escaping (Bool) -> Void) {
+        // In einer vollständigen Implementierung:
+        /*
+        do {
+            let result = assistant!.stop()
+            completion(Bool(result)!)
+        } catch {
+            print("Fehler beim Stoppen des Assistenten: \(error)")
+            completion(false)
+        }
+        */
+        
+        // Simulierter Stopp für den Prototyp
+        print("Assistent wird gestoppt...")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.assistantStatusPublisher.send(false)
+            completion(true)
+        }
+    }
+    
+    /// Sendet einen Befehl an den Assistenten
+    func sendCommand(_ command: String, completion: @escaping (String) -> Void) {
+        // In einer vollständigen Implementierung:
+        /*
+        do {
+            let result = assistant!.process_direct_query(command)
+            completion(String(result)!)
+        } catch {
+            print("Fehler beim Senden des Befehls: \(error)")
+            completion("Es ist ein Fehler aufgetreten: \(error)")
+        }
+        */
+        
+        // Simulierte Antwort für den Prototyp
+        print("Sende Befehl: \(command)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            let response = self.simulateResponse(to: command)
+            completion(response)
+        }
+    }
+    
+    /// Aktualisiert die Konfiguration des Assistenten
+    func updateConfiguration(
+        apiModel: String,
+        voiceEnabled: Bool,
+        screenEnabled: Bool,
+        wakeWord: String,
+        completion: @escaping (Bool) -> Void
+    ) {
+        // In einer vollständigen Implementierung:
+        /*
+        do {
+            let config = assistant!.config
+            config.ai_model = apiModel
+            config.voice_enabled = voiceEnabled
+            config.screen_analysis_enabled = screenEnabled
+            config.wake_word = wakeWord
+            
+            completion(true)
+        } catch {
+            print("Fehler beim Aktualisieren der Konfiguration: \(error)")
+            completion(false)
+        }
+        */
+        
+        // Simulierte Konfigurationsaktualisierung für den Prototyp
+        print("Konfiguration wird aktualisiert: API=\(apiModel), Voice=\(voiceEnabled), Screen=\(screenEnabled), WakeWord=\(wakeWord)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            completion(true)
+        }
+    }
+    
+    // MARK: - Simulierte Ereignisse für den Prototyp
+    
+    private func startSimulatedEvents() {
+        // Simuliert regelmäßige Ereignisse vom Python-Backend
+        
+        // Simulierte Bildschirmanalysen
+        Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            
+            let analyses = [
+                "Finder geöffnet mit 3 Dokumenten sichtbar",
+                "Safari aktiv mit geöffneter Webseite github.com",
+                "Mail mit 2 ungelesenen Nachrichten",
+                "Systemeinstellungen-Fenster sichtbar",
+                "Visual Studio Code mit Python-Datei geöffnet"
+            ]
+            
+            let randomAnalysis = analyses.randomElement() ?? ""
+            self.screenAnalysisPublisher.send(randomAnalysis)
+        }
+        
+        // Simulierte Sprachkommandos (unwahrscheinlicher)
+        Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
+            
+            // Nur manchmal ein Sprachkommando simulieren
+            if Int.random(in: 1...10) > 8 {
+                let commands = [
+                    "Öffne Safari",
+                    "Wie spät ist es?",
+                    "Schreibe eine E-Mail",
+                    "Was ist das Wetter morgen?"
+                ]
+                
+                let randomCommand = commands.randomElement() ?? ""
+                self.speechCommandPublisher.send(randomCommand)
+            }
+        }
+    }
+    
+    // Simuliert Antworten für den Prototyp
+    private func simulateResponse(to command: String) -> String {
+        let commandLower = command.lowercased()
+        
+        if commandLower.contains("hallo") || commandLower.contains("hi") {
+            return "Hallo! Wie kann ich dir helfen?"
+        } else if commandLower.contains("öffne") && commandLower.contains("safari") {
+            return "Ich öffne Safari für dich."
+        } else if commandLower.contains("schließe") {
+            return "Ich schließe die Anwendung für dich."
+        } else if commandLower.contains("mail") || commandLower.contains("email") {
+            return "Möchtest du eine neue E-Mail erstellen oder deine Mails überprüfen?"
+        } else if commandLower.contains("uhrzeit") || commandLower.contains("zeit") {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            let timeString = formatter.string(from: Date())
+            return "Es ist jetzt \(timeString) Uhr."
+        } else if commandLower.contains("hilfe") {
+            return "Ich kann dir bei vielen Aufgaben helfen: Anwendungen öffnen und schließen, Text eingeben, Informationen suchen und vieles mehr. Was möchtest du tun?"
+        } else {
+            return "Ich verstehe deine Anfrage. Wie kann ich dir dabei helfen?"
+        }
+    }
+}

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,18 @@
+# Mac Assistant GUI
+
+Dieser Ordner enthält den Swift/SwiftUI-basierten GUI-Prototyp für den Mac-Assistenten.
+
+## Komponenten
+
+- Menüleisten-Icon mit Status-Anzeige
+- Hauptinterface für Interaktionen
+- Einstellungsbereich
+- Onboarding-Prozess für neue Benutzer
+- Python-Integration via PyObjC-Bridge
+
+## Entwicklungsschritte
+
+1. Erstellen der grundlegenden SwiftUI-Ansichten
+2. Integration mit dem Python-Backend
+3. Implementierung der Benutzerinteraktionen
+4. Look & Feel optimieren für typische macOS-Erfahrung

--- a/gui/SettingsView.swift
+++ b/gui/SettingsView.swift
@@ -1,0 +1,294 @@
+// 
+// SettingsView.swift - Einstellungsansicht für den Mac-Assistenten
+// Erstellt am: 2025-05-04
+// Änderungen:
+// - Initiale Implementierung der Einstellungsansicht
+// - Konfigurationsoptionen für API, Sprache und Bildschirmanalyse
+// - Berechtigungsverwaltung und Wakeword-Konfiguration
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var assistantManager: AssistantManager
+    @Environment(\.presentationMode) var presentationMode
+    
+    // Lokale Kopien der Einstellungen für zwei-Wege-Binding
+    @State private var apiModel: String
+    @State private var voiceEnabled: Bool
+    @State private var screenAnalysisEnabled: Bool
+    @State private var wakeWord: String
+    
+    // API-Schlüssel
+    @State private var openaiApiKey: String = ""
+    @State private var geminiApiKey: String = ""
+    
+    // Berechtigungsstatus
+    @State private var hasMicrophonePermission: Bool = false
+    @State private var hasScreenRecordingPermission: Bool = false
+    
+    // Initialisier mit den aktuellen Einstellungen
+    init() {
+        let manager = AssistantManager.shared
+        _apiModel = State(initialValue: manager.apiModel)
+        _voiceEnabled = State(initialValue: manager.voiceEnabled)
+        _screenAnalysisEnabled = State(initialValue: manager.screenAnalysisEnabled)
+        _wakeWord = State(initialValue: manager.wakeWord)
+        
+        // In einer vollständigen Implementierung würden die API-Schlüssel aus dem Keychain geladen
+        _openaiApiKey = State(initialValue: "")
+        _geminiApiKey = State(initialValue: "")
+        
+        // Berechtigungsstatus würde tatsächlich geprüft werden
+        _hasMicrophonePermission = State(initialValue: false)
+        _hasScreenRecordingPermission = State(initialValue: false)
+    }
+    
+    var body: some View {
+        TabView {
+            // Allgemeine Einstellungen
+            generalSettingsView
+                .tabItem {
+                    Label("Allgemein", systemImage: "gear")
+                }
+            
+            // API-Einstellungen
+            apiSettingsView
+                .tabItem {
+                    Label("API", systemImage: "network")
+                }
+            
+            // Berechtigungs-Einstellungen
+            permissionsView
+                .tabItem {
+                    Label("Berechtigungen", systemImage: "lock.shield")
+                }
+        }
+        .padding()
+        .frame(width: 450, height: 350)
+        .onAppear {
+            // Berechtigungsstatus prüfen (in einer vollständigen Implementierung)
+            checkPermissions()
+        }
+    }
+    
+    // MARK: - Allgemeine Einstellungen
+    
+    private var generalSettingsView: some View {
+        Form {
+            Section(header: Text("Basiskonfiguration")) {
+                Toggle("Spracherkennung aktivieren", isOn: $voiceEnabled)
+                    .disabled(!hasMicrophonePermission)
+                
+                if !hasMicrophonePermission && voiceEnabled {
+                    Text("Mikrofonberechtigung erforderlich")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+                
+                Toggle("Bildschirmanalyse aktivieren", isOn: $screenAnalysisEnabled)
+                    .disabled(!hasScreenRecordingPermission)
+                
+                if !hasScreenRecordingPermission && screenAnalysisEnabled {
+                    Text("Bildschirmaufnahmeberechtigung erforderlich")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+            
+            Section(header: Text("Sprachsteuerung")) {
+                TextField("Aufweckwort", text: $wakeWord)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .disabled(!voiceEnabled)
+                
+                Text("Der Assistent reagiert, wenn er dieses Wort hört.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Abbrechen") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                    
+                    Button("Speichern") {
+                        saveSettings()
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+        .padding()
+    }
+    
+    // MARK: - API-Einstellungen
+    
+    private var apiSettingsView: some View {
+        Form {
+            Section(header: Text("KI-Modell")) {
+                Picker("API-Anbieter", selection: $apiModel) {
+                    Text("OpenAI").tag("openai")
+                    Text("Google Gemini").tag("gemini")
+                }
+                .pickerStyle(RadioGroupPickerStyle())
+            }
+            
+            Section(header: Text("OpenAI-Konfiguration")) {
+                SecureField("OpenAI API-Schlüssel", text: $openaiApiKey)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .disabled(apiModel != "openai")
+                
+                if apiModel == "openai" && openaiApiKey.isEmpty {
+                    Text("API-Schlüssel wird benötigt für OpenAI")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+            
+            Section(header: Text("Google Gemini-Konfiguration")) {
+                SecureField("Google Gemini API-Schlüssel", text: $geminiApiKey)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .disabled(apiModel != "gemini")
+                
+                if apiModel == "gemini" && geminiApiKey.isEmpty {
+                    Text("API-Schlüssel wird benötigt für Gemini")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+        }
+        .padding()
+    }
+    
+    // MARK: - Berechtigungsansicht
+    
+    private var permissionsView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Benötigte Berechtigungen")
+                .font(.headline)
+            
+            // Mikrofonberechtigung
+            HStack {
+                Image(systemName: hasMicrophonePermission ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundColor(hasMicrophonePermission ? .green : .red)
+                    .font(.title2)
+                
+                VStack(alignment: .leading) {
+                    Text("Mikrofonzugriff")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    Text("Wird für die Spracherkennung benötigt")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button(hasMicrophonePermission ? "Erteilt" : "Erlauben") {
+                    requestMicrophonePermission()
+                }
+                .disabled(hasMicrophonePermission)
+            }
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(8)
+            
+            // Bildschirmaufnahmeberechtigung
+            HStack {
+                Image(systemName: hasScreenRecordingPermission ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundColor(hasScreenRecordingPermission ? .green : .red)
+                    .font(.title2)
+                
+                VStack(alignment: .leading) {
+                    Text("Bildschirmaufnahme")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    Text("Wird für die Bildschirmanalyse benötigt")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button(hasScreenRecordingPermission ? "Erteilt" : "Erlauben") {
+                    requestScreenRecordingPermission()
+                }
+                .disabled(hasScreenRecordingPermission)
+            }
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(8)
+            
+            Text("Um alle Funktionen nutzen zu können, muss der Mac-Assistent die Erlaubnis haben, auf dein Mikrofon und deinen Bildschirm zuzugreifen. Diese Berechtigungen können jederzeit in den Systemeinstellungen unter 'Sicherheit & Datenschutz' geändert werden.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.top)
+            
+            Spacer()
+        }
+        .padding()
+    }
+    
+    // MARK: - Hilfsmethoden
+    
+    private func saveSettings() {
+        // Einstellungen im AssistantManager aktualisieren
+        let manager = AssistantManager.shared
+        manager.apiModel = self.apiModel
+        manager.voiceEnabled = self.voiceEnabled
+        manager.screenAnalysisEnabled = self.screenAnalysisEnabled
+        manager.wakeWord = self.wakeWord
+        
+        // In einer vollständigen Implementierung:
+        // API-Schlüssel im Keychain speichern
+        // saveApiKeysToKeychain()
+        
+        // Einstellungen speichern
+        // manager.saveSettings()
+    }
+    
+    private func checkPermissions() {
+        // In einer vollständigen Implementierung:
+        // Tatsächliche Prüfung der Berechtigungen
+        
+        // Simulierte Berechtigungsprüfung für den Prototyp
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.hasMicrophonePermission = UserDefaults.standard.bool(forKey: "mockMicPermission")
+            self.hasScreenRecordingPermission = UserDefaults.standard.bool(forKey: "mockScreenPermission")
+        }
+    }
+    
+    private func requestMicrophonePermission() {
+        // In einer vollständigen Implementierung:
+        // Tatsächliche Anfrage für Mikrofonzugriff
+        
+        // Simulierte Anfrage für den Prototyp
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.hasMicrophonePermission = true
+            UserDefaults.standard.set(true, forKey: "mockMicPermission")
+        }
+    }
+    
+    private func requestScreenRecordingPermission() {
+        // In einer vollständigen Implementierung:
+        // Tatsächliche Anfrage für Bildschirmaufnahme
+        
+        // Simulierte Anfrage für den Prototyp
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.hasScreenRecordingPermission = true
+            UserDefaults.standard.set(true, forKey: "mockScreenPermission")
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+            .environmentObject(AssistantManager.shared)
+    }
+}


### PR DESCRIPTION
Dieser Pull Request fügt die grundlegende SwiftUI-basierte Benutzeroberfläche für den Mac-Assistenten hinzu.

## Funktionen
- Menüleisten-Icon mit Popup-Interface
- Chat-Interface für die Kommunikation mit dem Assistenten
- Einstellungsbildschirm für Konfigurationen
- Python-Bridge für die Integration mit dem Python-Backend
- Simulierte Funktionalität für den Prototyp

## Nächste Schritte
- Implementierung der tatsächlichen Integration mit dem Python-Backend
- Optimierung der Benutzeroberfläche
- Implementierung der macOS-spezifischen Berechtigungsabfragen
- Paketierung als vollständige macOS-App